### PR TITLE
fix automake comment

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -4,7 +4,7 @@ include_HEADERS=include/libsoc_gpio.h
 libsoc_la_SOURCES = gpio.c
 libsoc_la_CPPFLAGS = -I${top_srcdir}/lib/include
 
-dnl interface : source : age
+## interface : source : age
 
 libsoc_la_LDFLAGS = -version-info 1:0:1
 


### PR DESCRIPTION
Makefile.am is not processed by m4, that's why 'dnl' statement
doesn't introduce a comment. Use '##' instead.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
