### PR TITLE
pwm: fix subscription error

### DIFF
--- a/lib/pwm.c
+++ b/lib/pwm.c
@@ -359,8 +359,6 @@ int libsoc_pwm_get_polarity(pwm *pwm)
     return EXIT_FAILURE;
   }
 
-  tmp_str[1] = NULL;
-
   if (strncmp(tmp_str, "i", 1) == 0)
   {
     polarity = INVERSED;


### PR DESCRIPTION
tmp_str array has a size of 1, so tmp_str[1] access is out of range.
Besides file_read_str() reads only one byte and strncmp() compares only
one byte too.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
