### PR TITLE
gpio: remove check for MAX_GPIO_ID

### DIFF
--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -14,7 +14,6 @@
 #include "libsoc_gpio.h"
 
 #define STR_BUF 256
-#define MAX_GPIO_ID 255
 
 const char gpio_level_strings[2][STR_BUF] = { "0", "1" };
 const char gpio_direction_strings[2][STR_BUF] = { "in", "out" };
@@ -66,12 +65,6 @@ libsoc_gpio_request (unsigned int gpio_id, enum gpio_mode mode)
     }
 
   libsoc_gpio_debug (__func__, gpio_id, "requested gpio");
-
-  if (gpio_id > MAX_GPIO_ID)
-    {
-      libsoc_gpio_debug (__func__, gpio_id, "gpio out of range (0-255)");
-      return NULL;
-    }
 
   sprintf (tmp_str, "/sys/class/gpio/gpio%d/value", gpio_id);
 


### PR DESCRIPTION
Remove this check, as max GPIO number can vary from platform to
platform.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
