### PR TITLE
gpio: move pthread header inclusion to libsoc_gpio.h

### DIFF
--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -4,7 +4,6 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <poll.h>
-#include <pthread.h>
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>

--- a/lib/include/libsoc_gpio.h
+++ b/lib/include/libsoc_gpio.h
@@ -1,6 +1,8 @@
 #ifndef _LIBSOC_GPIO_H_
 #define _LIBSOC_GPIO_H_
 
+#include <pthread.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixes following compile time error:

libsoc_gpio.h:21:2: error: unknown type name 'pthread_t'

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
