### PR TITLE
Add optional python wrapper to gpio APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,10 @@ clean_all.sh
 build_all.sh
 sync_all.sh
 
-Makefile
-Makefile.in
 aclocal.m4
 arm-oe-linux-gnueabi-libtool
 autom4te.cache/
+bindings/python/gpio.py
 compile
 config.guess
 config.log
@@ -15,13 +14,10 @@ config.sub
 configure
 depcomp
 install-sh
-lib/.deps/
-lib/.libs/
-lib/Makefile
-lib/Makefile.in
-lib/libsoc.la
-lib/libsoc_la-gpio.lo
-lib/libsoc_la-gpio.o
+*.deps/
+*.libs
+*Makefile
+*Makefile.in
 ltmain.sh
 missing
 test/gpio_test
@@ -30,6 +26,8 @@ test/i2c_test
 test/pwm_test
 libtool
 libsoc.pc
+*.la
 *.lo
 *.o
+*.pyc
 *.swp

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,3 +10,6 @@ SUBDIRS=lib
 if BOARD
 SUBDIRS += contrib/board_files
 endif
+if PYTHON
+SUBDIRS += bindings/python
+endif

--- a/README
+++ b/README
@@ -68,6 +68,7 @@ included to setup the build. Exact steps:
                   the fastest operation but at the cost of any debug
                   print outs. Ommiting this flag will leave debug
                   enabled.
+--enable-python : enable python language bindings to libsoc API.
 --enable-board  : install board specific GPIO pin mappings file. This
                   enables the use of the libsoc_board_gpio_id function
                   to look up GPIO ID's based on how the pin is named for

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,0 +1,8 @@
+libsocdir = $(pyexecdir)/libsoc
+libsoc_PYTHON = __init__.py gpio.py
+
+AM_CPPFLAGS = -I/usr/include/python$(PYTHON_VERSION) -I../../include/lib
+
+libsoc_LTLIBRARIES = _libsoc.la
+_libsoc_la_LDFLAGS = -module -avoid-version -export-symbols-regex init_libsoc
+_libsoc_la_SOURCES = gpio_python.c

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -4,5 +4,5 @@ libsoc_PYTHON = __init__.py gpio.py
 AM_CPPFLAGS = -I/usr/include/python$(PYTHON_VERSION) -I../../include/lib
 
 libsoc_LTLIBRARIES = _libsoc.la
-_libsoc_la_LDFLAGS = -module -avoid-version -export-symbols-regex init_libsoc
+_libsoc_la_LDFLAGS = -lsoc -module -avoid-version -export-symbols-regex init_libsoc
 _libsoc_la_SOURCES = gpio_python.c

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -1,0 +1,2 @@
+from _libsoc import *  # NOQA
+from gpio import *     # NOQA

--- a/bindings/python/gpio.py.in
+++ b/bindings/python/gpio.py.in
@@ -1,0 +1,106 @@
+import atexit
+import contextlib
+import ctypes
+
+from _libsoc import (
+    DIRECTION_INPUT, DIRECTION_OUTPUT,
+    EDGE_BOTH, EDGE_FALLING, EDGE_NONE, EDGE_RISING,
+    LS_SHARED, LS_GREEDY, LS_WEAK,
+)
+
+
+class GPIO(object):
+    _lib = ctypes.CDLL('@prefix@/lib/libsoc.so')
+    _board_config = None
+
+    def __init__(self, id, direction, edge=EDGE_NONE, mode=LS_SHARED):
+        self.id = id
+        if not isinstance(id, int):
+            raise TypeError('Invalid gpio id must be an "int"')
+        if mode not in (LS_SHARED, LS_GREEDY, LS_WEAK):
+            raise ValueError('Invalid GPIO mode: %d' % mode)
+        if direction not in (DIRECTION_INPUT, DIRECTION_OUTPUT):
+            raise ValueError('Invalid GPIO direction: %d' % direction)
+        edges = (EDGE_RISING, EDGE_FALLING, EDGE_NONE, EDGE_BOTH)
+        if direction == DIRECTION_INPUT and edge not in edges:
+            raise ValueError('Invalid GPIO edge: %d' % edge)
+
+        self.mode = mode
+        self.direction = direction
+        self.edge = edge
+        self._gpio = None
+
+    def open(self):
+        assert self._gpio is None
+        self._gpio = GPIO._lib.libsoc_gpio_request(self.id, self.mode)
+        if self._gpio == 0:  # NULL from native code
+            raise IOError('Unable to open GPIO_%d' % self.id)
+        GPIO._lib.libsoc_gpio_set_direction(self._gpio, self.direction)
+        if self.direction == DIRECTION_INPUT:
+            if GPIO._lib.libsoc_gpio_set_edge(self._gpio, self.edge) != 0:
+                raise IOError('Error setting edge for GPIO_%d' % self.id)
+
+    def close(self):
+        if self._gpio:
+            GPIO._lib.libsoc_gpio_free(self._gpio)
+            self._gpio = None
+
+    def get_direction(self):
+        d = GPIO._lib.libsoc_gpio_get_direction(self._gpio)
+        if d == -1:
+            raise IOError('Error reading GPIO_%d direction: %d' % self.id)
+        return d
+
+    @staticmethod
+    def gpio_id(pin):
+        if not GPIO._board_config:
+            GPIO._board_config = GPIO._lib.libsoc_board_init()
+            atexit.register(GPIO._lib.libsoc_board_free, GPIO._board_config)
+        gpio = GPIO._lib.libsoc_board_gpio_id(GPIO._board_config, pin)
+        if gpio == -1:
+            raise ValueError('Invalid GPIO pin name(%s)' % pin)
+        return gpio
+
+    @staticmethod
+    def set_debug(enabled):
+        v = 0
+        if enabled:
+            v = 1
+        GPIO._lib.libsoc_set_debug(v)
+
+    def set_high(self):
+        assert self.direction == DIRECTION_OUTPUT
+        GPIO._lib.libsoc_gpio_set_level(self._gpio, 1)
+
+    def set_low(self):
+        assert self.direction == DIRECTION_OUTPUT
+        GPIO._lib.libsoc_gpio_set_level(self._gpio, 0)
+
+    def is_high(self):
+        l = GPIO._lib.libsoc_gpio_get_level(self._gpio)
+        if l == -1:
+            raise IOError('Error reading GPIO_%d level' % self.id)
+        return l == 1
+
+    def wait_for_interrupt(self, timeout):
+        assert self.direction == DIRECTION_INPUT
+        if self._lib.libsoc_gpio_wait_interrupt(self._gpio, timeout) != 0:
+            raise IOError('Error waiting for interrupt on GPIO_%d' % self.id)
+
+    def get_edge(self):
+        assert self.direction == DIRECTION_INPUT
+        e = GPIO._lib.libsoc_gpio_get_edge(self._gpio)
+        if e == -1:
+            raise IOError('Error reading GPIO_%d edge' % self.id)
+        return e
+
+
+@contextlib.contextmanager
+def activate_gpios(gpios):
+    try:
+        for g in gpios:
+            g.open()
+        yield
+    finally:
+        for g in reversed(gpios):
+            g.close()

--- a/bindings/python/gpio.py.in
+++ b/bindings/python/gpio.py.in
@@ -6,6 +6,7 @@ from _libsoc import (
     DIRECTION_INPUT, DIRECTION_OUTPUT,
     EDGE_BOTH, EDGE_FALLING, EDGE_NONE, EDGE_RISING,
     LS_SHARED, LS_GREEDY, LS_WEAK,
+    start_gpio_cb,
 )
 
 
@@ -13,7 +14,8 @@ class GPIO(object):
     _lib = ctypes.CDLL('@prefix@/lib/libsoc.so')
     _board_config = None
 
-    def __init__(self, id, direction, edge=EDGE_NONE, mode=LS_SHARED):
+    def __init__(self, id, direction, edge=EDGE_NONE, mode=LS_SHARED,
+                 callback=None):
         self.id = id
         if not isinstance(id, int):
             raise TypeError('Invalid gpio id must be an "int"')
@@ -28,6 +30,7 @@ class GPIO(object):
         self.mode = mode
         self.direction = direction
         self.edge = edge
+        self.callback = callback
         self._gpio = None
 
     def open(self):
@@ -39,9 +42,13 @@ class GPIO(object):
         if self.direction == DIRECTION_INPUT:
             if GPIO._lib.libsoc_gpio_set_edge(self._gpio, self.edge) != 0:
                 raise IOError('Error setting edge for GPIO_%d' % self.id)
+            if self.callback:
+                start_gpio_cb(self._gpio, self.callback)
 
     def close(self):
         if self._gpio:
+            if self.direction == DIRECTION_INPUT and self.callback:
+                GPIO._lib.libsoc_gpio_callback_interrupt_cancel(self._gpio)
             GPIO._lib.libsoc_gpio_free(self._gpio)
             self._gpio = None
 

--- a/bindings/python/gpio_python.c
+++ b/bindings/python/gpio_python.c
@@ -1,0 +1,33 @@
+#include <Python.h>
+
+#include "libsoc_gpio.h"
+
+static PyMethodDef functions[] = {
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+PyMODINIT_FUNC
+init_libsoc(void)
+{
+  PyObject *m;
+  m = Py_InitModule ("_libsoc", functions);
+
+  PyModule_AddIntConstant(m, "DIRECTION_ERROR", DIRECTION_ERROR);
+  PyModule_AddIntConstant(m, "DIRECTION_INPUT", INPUT);
+  PyModule_AddIntConstant(m, "DIRECTION_OUTPUT", OUTPUT);
+
+  PyModule_AddIntConstant(m, "LEVEL_ERROR", LEVEL_ERROR);
+  PyModule_AddIntConstant(m, "LEVEL_LOW", LOW);
+  PyModule_AddIntConstant(m, "LEVEL_HIGH", HIGH);
+
+  PyModule_AddIntConstant(m, "EDGE_ERROR", EDGE_ERROR);
+  PyModule_AddIntConstant(m, "EDGE_RISING", RISING);
+  PyModule_AddIntConstant(m, "EDGE_FALLING", FALLING);
+  PyModule_AddIntConstant(m, "EDGE_NONE", NONE);
+  PyModule_AddIntConstant(m, "EDGE_BOTH", BOTH);
+
+  PyModule_AddIntConstant(m, "LS_SHARED", LS_SHARED);
+  PyModule_AddIntConstant(m, "LS_GREEDY", LS_GREEDY);
+  PyModule_AddIntConstant(m, "LS_WEAK", LS_WEAK);
+}
+

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,11 @@ AS_IF([test "x$enable_debug" != "xno"], [
   AC_DEFINE([DEBUG])
 ])
 
+AM_PATH_PYTHON(2.7)
+AC_ARG_ENABLE([python],
+    AS_HELP_STRING([--enable-python], [Enable python language bindings to libsoc API.]))
+AM_CONDITIONAL([PYTHON], [test "x$enable_python" != "xno"])
+
 AC_ARG_ENABLE([board],
     AS_HELP_STRING([--enable-board=BOARD], [Enable installation of board config]))
 
@@ -36,5 +41,6 @@ AM_CONDITIONAL([BOARD], [test "x$enable_board" != x])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-AC_CONFIG_FILES(Makefile lib/Makefile contrib/board_files/Makefile libsoc.pc)
+AC_CONFIG_FILES(Makefile lib/Makefile contrib/board_files/Makefile bindings/python/Makefile bindings/python/gpio.py libsoc.pc)
 AC_OUTPUT
+

--- a/test/gpio_test.py
+++ b/test/gpio_test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+import threading
+import time
+
+from libsoc import gpio
+
+
+def test_wait_for_interrupt(gpio_in, gpio_out):
+    def signaller(gpio_out, event):
+        event.wait()
+        # wait 1/10th of a second and create a falling interrupt
+        time.sleep(0.1)
+        gpio_out.set_high()
+        gpio_out.set_low()
+
+    gpio_out.set_low()
+    event = threading.Event()
+    t = threading.Thread(target=signaller, args=(gpio_out, event))
+    t.start()
+
+    gpio_in._lib.libsoc_gpio_set_edge(gpio_in._gpio, gpio.EDGE_FALLING)
+    event.set()
+    # wait up to one second for the interrupt
+    gpio_in.wait_for_interrupt(1000)
+
+
+def main(gpio_in, gpio_out):
+    gpio_in = gpio.GPIO(gpio_in, gpio.DIRECTION_INPUT)
+    gpio_out = gpio.GPIO(gpio_out, gpio.DIRECTION_OUTPUT)
+
+    with gpio.activate_gpios((gpio_in, gpio_out)):
+        assert gpio.DIRECTION_INPUT == gpio_in.get_direction()
+        assert gpio.DIRECTION_OUTPUT == gpio_out.get_direction()
+
+        gpio_out.set_high()
+        assert gpio_out.is_high()
+        assert gpio_in.is_high()
+
+        gpio_out.set_low()
+        assert not gpio_out.is_high()
+        assert not gpio_in.is_high()
+
+        gpio.GPIO.set_debug(False)
+        for i in range(1000):
+            gpio_out.set_high()
+            gpio_out.set_low()
+
+        gpio.GPIO.set_debug(True)
+        edges = (gpio.EDGE_RISING, gpio.EDGE_FALLING,
+                 gpio.EDGE_BOTH, gpio.EDGE_NONE)
+        for edge in edges:
+            gpio_in._lib.libsoc_gpio_set_edge(gpio_in._gpio, edge)
+            assert edge == gpio_in.get_edge()
+
+        test_wait_for_interrupt(gpio_in, gpio_out)
+
+
+if __name__ == '__main__':
+    import os
+    gpio_in = int(os.environ.get('GPIO_IN', '7'))
+    gpio_out = int(os.environ.get('GPIO_OUT', '115'))
+    main(gpio_in, gpio_out)


### PR DESCRIPTION
Hey Jack,

This is a patch I've been using to do most of my actual testing of libsoc. It adds a "pythonic" wrapper to your native library. I use this library to drive my most common unit test for an LED:

 http://paste.ubuntu.com/12864304/

I understand if you don't want to take on the burden of having Python code in your tree.