### PR TITLE
board_files: rename dragonboard to dragonboard410c

### DIFF
--- a/contrib/board_files/dragonboard410c/libsoc_gpio.conf
+++ b/contrib/board_files/dragonboard410c/libsoc_gpio.conf
@@ -1,4 +1,4 @@
-# dragonboard pin layout
+# dragonboard 410c pin layout
 #<Pin Name> <SoC Num>
 GPIO_A = 36
 GPIO_B = 12


### PR DESCRIPTION
Dragonboard is a generic name to refer to Qualcomm Snapdragon based development
boards. It does not make sense to use that generic name to identify a single
board. Right now 'dragonboard' was used to refer to the 96boards.org compatible
DragonBoard 410c, so change the name accordingly.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>