### PR TITLE
Make board file support more packaging friendly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,4 @@ pkgconfig_DATA = libsoc.pc
 EXTRA_DIST = libsoc.pc.in
 CLEANFILES = libsoc.pc
 
-SUBDIRS=lib
-if BOARD
-SUBDIRS += contrib/board_files
-endif
+SUBDIRS=lib contrib/board_files

--- a/README
+++ b/README
@@ -62,17 +62,22 @@ included to setup the build. Exact steps:
 
 1) ./autogen.sh
 2) ./configure [--disable-debug] [--enable-board=<board>]
+               [--with-board-configs]
 3) make
 
---disable-debug : disables the debug code, turn off the debug to get
-                  the fastest operation but at the cost of any debug
-                  print outs. Ommiting this flag will leave debug
-                  enabled.
---enable-board  : install board specific GPIO pin mappings file. This
-                  enables the use of the libsoc_board_gpio_id function
-                  to look up GPIO ID's based on how the pin is named for
-                  a supported board. Supported board can be found under
-                  ./contrib/board_files
+--disable-debug      : disables the debug code, turn off the debug to
+                       get the fastest operation but at the cost of any
+                       debug print outs. Ommiting this flag will leave
+                       debug enabled.
+--enable-board       : install board specific GPIO pin mappings file.
+                       This enables the use of the libsoc_board_gpio_id
+                       function to look up GPIO ID's based on how the
+                       pin is named for a supported board. Supported
+                       board can be found under ./contrib/board_files.
+                       If --with-board-configs is also used, a symlink
+                       will be created.
+--with-board-configs : install all the contributed board configuration
+                       files to $PREFIX/share/libsoc.
 
 Dependencies
 ------------------------------------------------------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,10 @@ AS_IF([test "x$enable_debug" != "xno"], [
   AC_DEFINE([DEBUG])
 ])
 
+AC_ARG_WITH([board-configs],
+    AS_HELP_STRING([--with-board-configs], [Install all board config files]))
+AM_CONDITIONAL([BOARD_CONFIGS], [test "x$with_board_configs" = xyes])
+
 AC_ARG_ENABLE([board],
     AS_HELP_STRING([--enable-board=BOARD], [Enable installation of board config]))
 

--- a/contrib/board_files/Makefile.am
+++ b/contrib/board_files/Makefile.am
@@ -1,1 +1,39 @@
+BOARD_FILES = $(shell cd $(srcdir); find ./ -name \*.conf)
+
+if BOARD_CONFIGS
+# Copy all board files to share/libsoc/...
+install-data-local:
+	set -x ;\
+	pushd $(srcdir) ;\
+	for p in $(BOARD_FILES); do \
+		$(INSTALL_DATA) -m 755 -d "$(DESTDIR)$(pkgdatadir)/$$(dirname $$p)";\
+		$(INSTALL_DATA) $$p "$(DESTDIR)$(pkgdatadir)/$$(dirname $$p)/" || exit $$?;\
+	done ; popd ; set +x
+if BOARD
+# Delete current libsoc_gpio.conf if it exists, then symlink the selected board
+	files=libsoc_gpio.conf ;\
+	dir='$(DESTDIR)$(sysconfdir)'; $(am__uninstall_files_from_dir) ;\
+	ln -s "$(DESTDIR)$(pkgdatadir)/@board@/libsoc_gpio.conf" "$(sysconfdir)/"
+endif
+
+uninstall-local:
+	files="$(BOARD_FILES)" ;\
+	dir='$(DESTDIR)$(pkgdatadir)'; $(am__uninstall_files_from_dir)
+	for p in $(BOARD_FILES); do \
+		if test -z "$$(ls $(DESTDIR)$(pkgdatadir)/$$(dirname $$p))" ; then \
+			rmdir "$(DESTDIR)$(pkgdatadir)/$$(dirname $$p)" ;\
+		fi ;\
+	done ;\
+	if test -z "$$(ls $(DESTDIR)$(pkgdatadir))" ; then \
+		rmdir "$(DESTDIR)$(pkgdatadir)" ;\
+	fi
+if BOARD
+	files=libsoc_gpio.conf ;\
+	dir='$(DESTDIR)$(sysconfdir)'; $(am__uninstall_files_from_dir)
+endif
+else
+if BOARD
+# Just copy the one board config to etc.
 sysconf_DATA = @board@/libsoc_gpio.conf
+endif
+endif


### PR DESCRIPTION
Hey Jack - this goes with the "symlink" method. If we really want a config file, I think its probably worth doing in a separate commit since it will be largely C changes:

The current way board support is done with libsoc doesn't play well with
distribution packaging logic. This changes things so that:

1) board files are always installed to:
 $PREFIX/share/libsoc/
                      beaglebone/libsoc_gpio.conf
                      hikey/libsoc_gpio.conf
		      ...

2) if --enable-board=<board> is specified a symlink to the proper file
will be added.

Automake doesn't have any native support for recursively copying the
contents of a directory, so added some custom logic in
install-data-local and uninstall-local to handle this.

Signed-off-by: Andy Doan <andy.doan@linaro.org>