### PR TITLE
configure: build from external directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_ARG_ENABLE([board],
     AS_HELP_STRING([--enable-board=BOARD], [Enable installation of board config]))
 
 AS_IF([test "x$enable_board" != "x"], [
-  valid_boards=`ls contrib/board_files/ | grep -v Makefile | tr '\n' ' '`
+  valid_boards=`ls $srcdir/contrib/board_files/ | grep -v Makefile | tr '\n' ' '`
   for x in $valid_boards ; do
     test "$x" = "$enable_board" && found=1
   done


### PR DESCRIPTION
without this change, configure fails unable to find the board names

[jramirez@calypso build-libsoc (master *)]$ ../../libsoc/configure  --build=x86_64 --host=aarch64-linux-gnu  CFLAGS="-march=armv8-a" --prefix=/usr/libsoc --enable-board="hikey"
checking build system type... x86_64-pc-none
checking host system type... aarch64-unknown-linux-gnu
checking target system type... aarch64-unknown-linux-gnu
checking for aarch64-linux-gnu-gcc... aarch64-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... yes
[...]
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for library containing pthread_create, pthread_cancel... -lpthread
configure: error: Invalid board name: hikey, must be one of: 
