### PR TITLE
Remove inline keyword

### DIFF
--- a/lib/debug.c
+++ b/lib/debug.c
@@ -3,7 +3,7 @@
 
 int debug = 0;
 
-inline void
+void
 libsoc_debug (const char *func, char *format, ...)
 {
 #ifdef DEBUG
@@ -25,7 +25,7 @@ libsoc_debug (const char *func, char *format, ...)
 #endif
 }
 
-inline void
+void
 libsoc_warn (const char *format, ...)
 {
   va_list args;

--- a/lib/file.c
+++ b/lib/file.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-inline int file_open(const char *path, int flags)
+int file_open(const char *path, int flags)
 {
   int fd = open(path, flags);
 
@@ -16,7 +16,7 @@ inline int file_open(const char *path, int flags)
   return fd;
 }
 
-inline int file_write(int fd, const char *str, int len)
+int file_write(int fd, const char *str, int len)
 {
   int ret_len = write(fd, str, len);
 
@@ -29,7 +29,7 @@ inline int file_write(int fd, const char *str, int len)
   return ret_len;
 }
 
-inline int file_read(int fd, void *buf, int count)
+int file_read(int fd, void *buf, int count)
 {
   lseek (fd, 0, SEEK_SET);
 
@@ -44,7 +44,7 @@ inline int file_read(int fd, void *buf, int count)
   return ret;
 }
 
-inline int file_valid(char *path)
+int file_valid(char *path)
 {
   if (access(path, F_OK) == 0)
   {
@@ -54,7 +54,7 @@ inline int file_valid(char *path)
   return 0;
 }
 
-inline int file_close(int fd)
+int file_close(int fd)
 {
   if (close(fd) < 0)
   {
@@ -67,7 +67,7 @@ inline int file_close(int fd)
 
 #define INT_STR_BUF 20
 
-inline int file_read_int_path(char *path, int *tmp)
+int file_read_int_path(char *path, int *tmp)
 {
   int fd, ret;
 
@@ -88,7 +88,7 @@ inline int file_read_int_path(char *path, int *tmp)
   return EXIT_SUCCESS;
 }
 
-inline int file_read_int_fd(int fd, int *tmp)
+int file_read_int_fd(int fd, int *tmp)
 {
   char buf[INT_STR_BUF];
 
@@ -102,7 +102,7 @@ inline int file_read_int_fd(int fd, int *tmp)
   return EXIT_SUCCESS;
 }
 
-inline int file_write_int_path(char *path, int val)
+int file_write_int_path(char *path, int val)
 {
   int fd, ret;
 
@@ -123,7 +123,7 @@ inline int file_write_int_path(char *path, int val)
   return EXIT_SUCCESS;
 }
 
-inline int file_write_int_fd(int fd, int val)
+int file_write_int_fd(int fd, int val)
 {
   char buf[INT_STR_BUF];
 
@@ -137,7 +137,7 @@ inline int file_write_int_fd(int fd, int val)
   return EXIT_SUCCESS;
 }
 
-inline int file_read_str(char *path, char *tmp, int buf_len)
+int file_read_str(char *path, char *tmp, int buf_len)
 {
   int fd;
 
@@ -161,7 +161,7 @@ inline int file_read_str(char *path, char *tmp, int buf_len)
   return EXIT_SUCCESS;
 }
 
-inline int file_write_str(char *path, char* buf, int len)
+int file_write_str(char *path, char* buf, int len)
 {
   int fd;
 
@@ -184,4 +184,3 @@ inline int file_write_str(char *path, char* buf, int len)
 
   return EXIT_SUCCESS;
 }
-

--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -18,7 +18,7 @@ const char gpio_level_strings[2][STR_BUF] = { "0", "1" };
 const char gpio_direction_strings[2][STR_BUF] = { "in", "out" };
 const char gpio_edge_strings[4][STR_BUF] = { "rising", "falling", "none", "both" };
 
-inline void
+void
 libsoc_gpio_debug (const char *func, int gpio, char *format, ...)
 {
 #ifdef DEBUG

--- a/lib/i2c.c
+++ b/lib/i2c.c
@@ -11,7 +11,7 @@
 #include "libsoc_debug.h"
 #include "libsoc_file.h"
 
-inline void
+void
 libsoc_i2c_debug (const char *func, i2c * i2c, char *format, ...)
 {
 #ifdef DEBUG

--- a/lib/include/libsoc_debug.h
+++ b/lib/include/libsoc_debug.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
-inline void libsoc_debug(const char *func, char *format, ...) __attribute__((format(printf, 2, 3)));
-inline void libsoc_warn(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void libsoc_debug(const char *func, char *format, ...) __attribute__((format(printf, 2, 3)));
+void libsoc_warn(const char *format, ...) __attribute__((format(printf, 1, 2)));
 int libsoc_get_debug();
 void libsoc_set_debug(int level);
 

--- a/lib/include/libsoc_file.h
+++ b/lib/include/libsoc_file.h
@@ -6,14 +6,14 @@ extern "C" {
 #endif
 
 int file_open(const char* path, int flags);
-inline int file_write(int fd, const char* str, int len);
-inline int file_read(int fd, void *buf, int count);
-inline int file_valid(char* path);
-inline int file_close(int fd);
-inline int file_write_int(char *path, int val);
-inline int file_read_str(char *path, char *tmp, int buf_len);
-inline int file_write_str(char *path, char* buf, int len);
-inline int file_read_int(char *path, int *tmp);
+int file_write(int fd, const char* str, int len);
+int file_read(int fd, void *buf, int count);
+int file_valid(char* path);
+int file_close(int fd);
+int file_write_int(char *path, int val);
+int file_read_str(char *path, char *tmp, int buf_len);
+int file_write_str(char *path, char* buf, int len);
+int file_read_int(char *path, int *tmp);
 
 #ifdef __cplusplus
 }

--- a/lib/pwm.c
+++ b/lib/pwm.c
@@ -15,7 +15,7 @@
 static char pwm_polarity_strings[2][STR_BUF] = { "normal", "inversed" };
 static char pwm_enabled_strings[2][STR_BUF] = { "0", "1" };
 
-inline void libsoc_pwm_debug (const char *func, unsigned int chip,
+void libsoc_pwm_debug (const char *func, unsigned int chip,
   unsigned int pwm, char *format, ...)
 {
 #ifdef DEBUG

--- a/lib/spi.c
+++ b/lib/spi.c
@@ -12,7 +12,7 @@
 #include "libsoc_debug.h"
 #include "libsoc_file.h"
 
-inline void
+void
 libsoc_spi_debug (const char *func, spi * spi, char *format, ...)
 {
 #ifdef DEBUG


### PR DESCRIPTION
Fixes GCC5.x compilation issues related to C99 inline semantics.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>