### PR TITLE
spi: fix build against MUSL C library

### DIFF
--- a/lib/spi.c
+++ b/lib/spi.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/types.h>
+#include <linux/ioctl.h>
 #include <linux/spi/spidev.h>
 
 #include "libsoc_spi.h"


### PR DESCRIPTION
Without <linux/ioctl.h> include compiler cannot find _IOC_SIZEBITS
macro, when using MUSL C library.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>