### PR TITLE
board files: Add pin number mappings for 96Boards

### DIFF
--- a/contrib/board_files/bubblegum/libsoc_gpio.conf
+++ b/contrib/board_files/bubblegum/libsoc_gpio.conf
@@ -12,3 +12,17 @@ GPIO_I = 11
 GPIO_J = 10
 GPIO_K = 27
 GPIO_L = 26
+
+# include mappings by pin number on board
+GPIO_23 = 19
+GPIO_24 = 18
+GPIO_25 = 17
+GPIO_26 = 16
+GPIO_27 = 15
+GPIO_28 = 14
+GPIO_29 = 13
+GPIO_30 = 12
+GPIO_31 = 11
+GPIO_32 = 10
+GPIO_33 = 27
+GPIO_34 = 26

--- a/contrib/board_files/dragonboard410c/libsoc_gpio.conf
+++ b/contrib/board_files/dragonboard410c/libsoc_gpio.conf
@@ -12,3 +12,17 @@ GPIO_I = 35
 GPIO_J = 34
 GPIO_K = 28
 GPIO_L = 33
+
+# include mappings by pin number on board
+GPIO_23 = 36
+GPIO_24 = 12
+GPIO_25 = 13
+GPIO_26 = 69
+GPIO_27 = 115
+GPIO_28 = 4
+GPIO_29 = 24
+GPIO_30 = 25
+GPIO_31 = 35
+GPIO_32 = 34
+GPIO_33 = 28
+GPIO_34 = 33

--- a/contrib/board_files/hikey/libsoc_gpio.conf
+++ b/contrib/board_files/hikey/libsoc_gpio.conf
@@ -12,3 +12,17 @@ GPIO_I = 426
 GPIO_J = 433
 GPIO_K = 427
 GPIO_L = 434
+
+# include mappings by pin number on board
+GPIO_23 = 488
+GPIO_24 = 489
+GPIO_25 = 490
+GPIO_26 = 491
+GPIO_27 = 492
+GPIO_28 = 415
+GPIO_29 = 463
+GPIO_30 = 495
+GPIO_31 = 426
+GPIO_32 = 433
+GPIO_33 = 427
+GPIO_34 = 434


### PR DESCRIPTION
Many users find it easier to refer to pins based on their actual number
on the board. This allows users to uses either method, ie:

 GPIO_A = GPIO_23 = <gpio id of board>

Signed-off-by: Andy Doan <andy.doan@linaro.org>