### PR TITLE
I2c python

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,5 +1,5 @@
 libsocdir = $(pyexecdir)/libsoc
-libsoc_PYTHON = __init__.py gpio.py
+libsoc_PYTHON = __init__.py gpio.py i2c.py
 
 AM_CPPFLAGS = $(PYTHON_CFLAGS) -I${top_srcdir}/lib/include -DLIBSOC_SO=\"@prefix@/lib/libsoc.so\"
 

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,8 +1,8 @@
 libsocdir = $(pyexecdir)/libsoc
 libsoc_PYTHON = __init__.py gpio.py
 
-AM_CPPFLAGS = $(PYTHON_CFLAGS) -I${top_srcdir}/lib/include
+AM_CPPFLAGS = $(PYTHON_CFLAGS) -I${top_srcdir}/lib/include -DLIBSOC_SO=\"@prefix@/lib/libsoc.so\"
 
 libsoc_LTLIBRARIES = _libsoc.la
-_libsoc_la_LDFLAGS = -module -avoid-version -export-dynamic
+_libsoc_la_LDFLAGS = -module -avoid-version -export-dynamic $(PYTHON_LIBS)
 _libsoc_la_SOURCES = gpio_python.c

--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -1,2 +1,3 @@
 from ._libsoc import *  # NOQA
 from .gpio import *     # NOQA
+from .i2c import *      # NOQA

--- a/bindings/python/gpio_python.c
+++ b/bindings/python/gpio_python.c
@@ -9,6 +9,8 @@ static PyMethodDef functions[] = {
 static void
 _add_constants(PyObject *m)
 {
+  PyObject *mod, *func, *args, *api;
+
   PyModule_AddIntConstant(m, "DIRECTION_ERROR", DIRECTION_ERROR);
   PyModule_AddIntConstant(m, "DIRECTION_INPUT", INPUT);
   PyModule_AddIntConstant(m, "DIRECTION_OUTPUT", OUTPUT);
@@ -26,6 +28,16 @@ _add_constants(PyObject *m)
   PyModule_AddIntConstant(m, "LS_SHARED", LS_SHARED);
   PyModule_AddIntConstant(m, "LS_GREEDY", LS_GREEDY);
   PyModule_AddIntConstant(m, "LS_WEAK", LS_WEAK);
+
+  mod = PyImport_ImportModule("ctypes");
+  func = PyObject_GetAttrString(mod, "CDLL");
+  if (!PyCallable_Check(func))
+    PyErr_Print();
+
+  args = Py_BuildValue("(s)", LIBSOC_SO);
+  api = PyObject_CallObject(func, args);
+  Py_DECREF(args);
+  PyModule_AddObject(m, "api", api);
 }
 
 

--- a/bindings/python/i2c.py
+++ b/bindings/python/i2c.py
@@ -1,0 +1,63 @@
+import sys
+from ctypes import create_string_buffer
+
+from ._libsoc import api
+
+PY3 = sys.version_info >= (3, 0)
+
+
+class I2C(object):
+    def __init__(self, bus, address):
+        if not isinstance(bus, int):
+            raise TypeError('Invalid bus id must be an "int"')
+        if not isinstance(address, int):
+            raise TypeError('Invalid bus address must be an "int"')
+        self.bus = bus
+        self.addr = address
+        self._i2c = None
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def open(self):
+        '''Opens a file descriptor to the GPIO and configures it.'''
+        assert self._i2c is None
+        self._i2c = api.libsoc_i2c_init(self.bus, self.addr)
+        if self._i2c == 0:  # NULL from native code
+            raise IOError(
+                'Unable to open i2c bus(%d) addr(%d)' % (self.bus, self.addr))
+
+    def close(self):
+        '''Cleans up the memory and resources allocated by the open method.'''
+        if self._i2c:
+            api.libsoc_i2c_free(self._i2c)
+            self._i2c = None
+
+    @staticmethod
+    def set_debug(enabled):
+        v = 0
+        if enabled:
+            v = 1
+        api.libsoc_set_debug(v)
+
+    def set_timeout(self, timeout):
+        if not isinstance(timeout, int):
+            raise TypeError('Invalid timeout must be an "int"')
+        api.libsoc_i2c_set_timeout(self._i2c, timeout)
+
+    def read(self, num_bytes):
+        buff = create_string_buffer(num_bytes)
+        if api.libsoc_i2c_read(self._i2c, buff, num_bytes) == -1:
+            raise IOError('Error reading i2c device')
+        return buff.value
+
+    def write(self, byte_array):
+        if PY3:
+            buff = bytes(byte_array)
+        else:
+            buff = ''.join(map(chr, byte_array))
+        api.libsoc_i2c_write(self._i2c, buff, len(buff))

--- a/configure.ac
+++ b/configure.ac
@@ -61,5 +61,5 @@ AM_CONDITIONAL([BOARD], [test "x$enable_board" != x])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-AC_CONFIG_FILES(Makefile lib/Makefile contrib/board_files/Makefile bindings/python/Makefile bindings/python/gpio.py libsoc.pc)
+AC_CONFIG_FILES(Makefile lib/Makefile contrib/board_files/Makefile bindings/python/Makefile libsoc.pc)
 AC_OUTPUT

--- a/test/i2c_test.py
+++ b/test/i2c_test.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+from libsoc import I2C
+
+# This test is intended to be run with the Grove-LCD on I2C bus 0.
+# The test initializes the LCD and then sets the background to solid blue.
+LCD_BUS = 0
+LCD_ADDR = 0x62
+
+
+def main():
+    I2C.set_debug(1)
+    with I2C(LCD_BUS, LCD_ADDR) as lcd:
+        # initialize LCD
+        lcd.write((0x0, 0x00))
+        lcd.write((0x1, 0x00))
+        lcd.write((0x8, 0xAA))
+
+        lcd.write((0x2, 0xFF))  # Make blue background
+        assert b'\xFF' == lcd.read(1), 'Unable to read blue level'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds python support for the i2c interface in libsoc. The first two patches are some minor refactoring to make the native libsoc interface accessible outside of the GPIO class.