### PR TITLE
board support: add fallback probing method

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,4 +19,4 @@ libsoc_la_CPPFLAGS = -I${top_srcdir}/lib/include
 ## interface : source : age
 
 libsoc_la_LDFLAGS = -version-info 5:1:3
-AM_CFLAGS = -DGPIO_CONF=\"@sysconfdir@/libsoc_gpio.conf\"
+AM_CFLAGS = -DDATA_DIR=\"$(DESTDIR)$(pkgdatadir)\" -DGPIO_CONF=\"@sysconfdir@/libsoc_gpio.conf\"

--- a/lib/board.c
+++ b/lib/board.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "libsoc_board.h"
 #include "libsoc_debug.h"
@@ -11,7 +12,14 @@ _get_conf_file()
 {
   const char *name = getenv("LIBSOC_GPIO_CONF");
   if (name == NULL)
-    name = GPIO_CONF;
+    {
+      name = GPIO_CONF;
+      if (!access(name))
+        {
+          libsoc_warn("GPIO mapping file(%s) does not exist\n", name);
+          return NULL;
+        }
+    }
   return name;
 }
 
@@ -37,6 +45,9 @@ libsoc_board_init()
   pin_mapping *ptr;
   char *tmp;
   const char *conf = _get_conf_file();
+
+  if (!conf)
+    return NULL;
 
   bc = calloc(sizeof(board_config), 1);
 


### PR DESCRIPTION
Package maintainers trying to build a rootfs for multiple platforms
can't take advantage of the "--enable-board" flag and need a way to
detect the board at runtime. This serves those by adding some probing
logic as a fallback method.