### PR TITLE
python: allow request_gpios to take single GPIO

### DIFF
--- a/bindings/python/gpio.py
+++ b/bindings/python/gpio.py
@@ -137,6 +137,8 @@ class GPIO(object):
 
 @contextlib.contextmanager
 def request_gpios(gpios):
+    if not isinstance(gpios, tuple) and not isinstance(gpios, list):
+        gpios = (gpios,)
     try:
         for g in gpios:
             g.open()


### PR DESCRIPTION
This allows the function to work with three different inputs:

 request_gpios([1,2])  # list
 request_gpios((1,2))  # tuple
 request_gpios(1)      # a single gpio

Fixes bug #50

Signed-off-by: Andy Doan <andy.doan@linaro.org>