### PR TITLE
build: simplify the build logic when python bindings is enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,6 @@ CLEANFILES = libsoc.pc
 
 SUBDIRS=lib contrib/board_files
 
-if EN_PYTHON
+if HAVE_PYTHON
 SUBDIRS += bindings/python
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -24,26 +24,18 @@ AC_ARG_WITH([board-configs],
     AS_HELP_STRING([--with-board-configs], [Install all board config files]))
 AM_CONDITIONAL([BOARD_CONFIGS], [test "x$with_board_configs" = xyes])
 
-AC_ARG_ENABLE([python2],
-    AS_HELP_STRING([--enable-python2], [Enable python 2 language bindings to libsoc API.]))
+AC_ARG_ENABLE([python],
+    AS_HELP_STRING([--enable-python=PYTHON_VERSION],
+    [Enable Python language bindings to libsoc API. Either version 2 or 3.]))
 
-AS_IF([test "x$enable_python2" != x], [
-  AM_PATH_PYTHON(2)
-])
-
-AC_ARG_ENABLE([python3],
-    AS_HELP_STRING([--enable-python3], [Enable python 3 language bindings to libsoc API.]))
-
-AS_IF([test "x$enable_python3" != x], [
-  AS_IF([test "x$enable_python2" != x], [
-    AC_MSG_ERROR([--enable-python3 and --enable-python2 cannot both be selected.])
-  ])
-  AM_PATH_PYTHON(3)
-])
-
-AM_CONDITIONAL([EN_PYTHON], [test "x$enable_python2" != x || test "x$enable_python3" != x])
-
-AM_COND_IF([EN_PYTHON], [PKG_CHECK_MODULES([PYTHON], [python-"$PYTHON_VERSION"])])
+AS_CASE(["$enable_python"],
+  [2|3], [
+    AM_PATH_PYTHON("$enable_python")
+    PKG_CHECK_MODULES([PYTHON], [python-"$PYTHON_VERSION"])
+    AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
+  ],
+  [AC_MSG_NOTICE([Python version should be either 2 or 3.])]
+)
 
 AC_ARG_ENABLE([board],
     AS_HELP_STRING([--enable-board=BOARD], [Enable installation of board config]))


### PR DESCRIPTION
* Use a single argument (--enable-python=) to enable python binding build.
  It avoids to duplicate python2 and python3 code logic, prone to errors.

* Use the common HAVE_PYTHON automake conditional instead of the unusual
  EN_PYTHON variable.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>