### PR TITLE
board_files: Add file for SD600 Evaluation Board

### DIFF
--- a/contrib/board_files/sd600_eval.conf
+++ b/contrib/board_files/sd600_eval.conf
@@ -1,0 +1,32 @@
+[board]
+model = Arrow Electronics, APQ8064 DB600c
+
+[GPIO]
+# SD 600eval pin layout
+#<Pin Name> <SoC Num>
+GPIO-A = 35
+GPIO-B = 33
+GPIO-C = 55
+GPIO-D = 56
+GPIO-E = 29
+GPIO-F = 493
+GPIO-G = 0
+# GPIO-H is currently non-functional
+GPIO-I = 28
+GPIO-J = 30
+GPIO-K = 34
+GPIO-L = 31
+
+# include mappings by pin number on board
+GPIO-23 = 35
+GPIO-24 = 33
+GPIO-25 = 55
+GPIO-26 = 56
+GPIO-27 = 29
+GPIO-28 = 493
+GPIO-29 = 0
+# GPIO-30 is currently non-functional
+GPIO-31 = 28
+GPIO-32 = 30
+GPIO-33 = 34
+GPIO-34 = 31


### PR DESCRIPTION
This is a 96Boards CE Extended board based on the Snapdragon 600.

Signed-off-by: David Mandala <david.mandala@linaro.org>
Signed-off-by: Andy Doan <andy.doan@linaro.org>