### PR TITLE
Board and GPIO data hiding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ libsoc.pc
 *.o
 *.pyc
 *.swp
+*~

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -4,7 +4,6 @@ include_HEADERS = include/libsoc_gpio.h \
                   include/libsoc_i2c.h \
                   include/libsoc_pwm.h \
                   include/libsoc_board.h \
-                  include/libsoc_conffile.h \
                   include/libsoc_debug.h
 
 libsoc_la_SOURCES = gpio.c \

--- a/lib/board.c
+++ b/lib/board.c
@@ -1,5 +1,6 @@
 #include <dirent.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -7,6 +8,23 @@
 #include "libsoc_board.h"
 #include "libsoc_debug.h"
 #include "libsoc_file.h"
+#include "libsoc_conffile.h"
+
+/*
+ * The actual board_config type, to hold board specific information
+ * magic - A 32-bit magic constant to check validity of opaque pointer
+ * conf* - the board config file
+ */
+
+typedef struct {
+  uint32_t  magic;
+  conffile *conf;
+} board_config_imp;
+
+
+// Random (and probably) unique value
+#define MAGIC 0x6abc7940
+
 
 static const char *
 _get_conf_file()
@@ -39,10 +57,10 @@ _probe_config(conffile *conf)
   return 0;
 }
 
-static board_config *
+static board_config_imp *
 _probe()
 {
-  board_config *bc = NULL;
+  board_config_imp *bc = NULL;
   conffile *conf = NULL;
   const char *confs_dir = DATA_DIR;
   char tmp[PATH_MAX];
@@ -68,7 +86,7 @@ _probe()
                       if(_probe_config(conf))
 		        {
 			  libsoc_debug(__func__, "probing match for %s", tmp);
-                          bc = calloc(1, sizeof(board_config));
+                          bc = calloc(1, sizeof(board_config_imp));
                           bc->conf = conf;
 			}
 		      else
@@ -89,12 +107,12 @@ _probe()
 board_config*
 libsoc_board_init()
 {
-  board_config *bc = NULL;
+  board_config_imp *bc = NULL;
   const char *conf = _get_conf_file();
 
   if (!access(conf, F_OK))
     {
-      bc = calloc(sizeof(board_config), 1);
+      bc = calloc(sizeof(board_config_imp), 1);
       bc->conf = conffile_load(conf);
       if (!bc->conf)
         {
@@ -109,21 +127,34 @@ libsoc_board_init()
         libsoc_warn("Board config(%s) does not exist and could not be probed", conf);
     }
 
-  return bc;
+  if (bc != NULL) bc->magic = MAGIC;
+  
+  return (board_config*) bc;
 }
 
 void
-libsoc_board_free(board_config *config)
+libsoc_board_free(board_config *cfg)
 {
-  if (config)
-    {
-        conffile_free(config->conf);
-        free(config);
-    }
+  board_config_imp *config = (board_config_imp*) cfg;
+
+  if (!config || config->magic != MAGIC) {
+    libsoc_error(__func__, "Invalid board configuration.");
+    return;
+  }
+
+  conffile_free(config->conf);
+  free(config);
 }
 
-unsigned int
-libsoc_board_gpio_id(board_config *config, const char* pin)
+int
+libsoc_board_gpio_id(board_config *cfg, const char* pin)
 {
+  board_config_imp *config = (board_config_imp*) cfg;
+
+  if (!config || config->magic != MAGIC) {
+    libsoc_error(__func__, "Invalid board configuration.");
+    return -1;
+  }
+
   return conffile_get_int(config->conf, "GPIO", pin, -1);
 }

--- a/lib/debug.c
+++ b/lib/debug.c
@@ -40,6 +40,20 @@ libsoc_warn (const char *format, ...)
 }
 
 void
+libsoc_error (const char* func, const char *format, ...)
+{
+  va_list args;
+
+  fprintf (stderr, "libsoc-error: %s: ", func);
+
+  va_start (args, format);
+  vfprintf (stderr, format, args);
+  va_end (args);
+
+  fprintf (stderr, "\n");
+}
+
+void
 libsoc_set_debug (int level)
 {
 #ifdef DEBUG

--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -2,8 +2,10 @@
 #include <stdarg.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <poll.h>
+#include <pthread.h>
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
@@ -12,11 +14,50 @@
 #include "libsoc_debug.h"
 #include "libsoc_gpio.h"
 
+/**
+ * Internal representation of an interrupt callback
+ * int (*callback_fn)(void*) - the function to callback on interrupt
+ * void *callback_arg - the argument to pass to the callback function
+ * pthread_t *thread - the pthread struct on which the poll and
+ *  callback function runs
+ * int ready - signal when the pthread is ready to accept interrupts
+ */
+
+struct gpio_callback {
+  int (*callback_fn) (void *);
+  void *callback_arg;
+  pthread_t *thread;
+  int ready;
+};
+
+/**
+ * Internal (private) representation of a single requested gpio
+ * unsigned int gpio gpio id
+ * int value_fd file descriptor to gpio value file
+ * struct gpio_callback *callback - struct used to store interrupt callback data
+ * int shared - set if the request flag was shared and the GPIO was exported on request
+ */
+
+typedef struct {
+  uint32_t magic;
+  unsigned int gpio;
+  int value_fd;
+  struct gpio_callback *callback;
+  struct pollfd pfd;
+  int shared;
+} gpio_imp;
+
+/*
+ * Random (and probably) unique magic value
+ */
+#define MAGIC 0x63fc44f1 
+
+
 #define STR_BUF 256
 
-const char gpio_level_strings[2][STR_BUF] = { "0", "1" };
-const char gpio_direction_strings[2][STR_BUF] = { "in", "out" };
-const char gpio_edge_strings[4][STR_BUF] = { "rising", "falling", "none", "both" };
+const char gpio_level_strings[2][2] = { "0", "1" };
+const char gpio_direction_strings[2][4] = { "in", "out" };
+const char gpio_edge_strings[4][8] = { "rising", "falling", "none", "both" };
 
 void
 libsoc_gpio_debug (const char *func, int gpio, char *format, ...)
@@ -50,7 +91,7 @@ libsoc_gpio_debug (const char *func, int gpio, char *format, ...)
 gpio *
 libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
 {
-  gpio *new_gpio;
+  gpio_imp *new_gpio;
   char tmp_str[STR_BUF];
   int shared = 0;
 
@@ -115,7 +156,7 @@ libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
 	}
     }
 
-  new_gpio = malloc (sizeof (gpio));
+  new_gpio = malloc (sizeof (gpio_imp));
   if (new_gpio == NULL)
     return NULL;
 
@@ -138,16 +179,20 @@ libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
   new_gpio->pfd.events = POLLPRI;
   new_gpio->pfd.revents = 0;
 
+  new_gpio->magic = MAGIC;
+  
   return new_gpio;
 }
 
 int
-libsoc_gpio_free (gpio * gpio)
+libsoc_gpio_free (gpio * opaque)
 {
+  gpio_imp *gpio = (gpio_imp*) opaque;
+  
   char tmp_str[STR_BUF];
   int fd;
 
-  if (gpio == NULL)
+  if (gpio == NULL || gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return EXIT_FAILURE;
@@ -198,12 +243,14 @@ libsoc_gpio_free (gpio * gpio)
 }
 
 int
-libsoc_gpio_set_direction (gpio * current_gpio, gpio_direction direction)
+libsoc_gpio_set_direction (gpio * opaque, gpio_direction direction)
 {
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+
   int fd;
   char path[STR_BUF];
 
-  if (current_gpio == NULL)
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return EXIT_FAILURE;
@@ -230,12 +277,14 @@ libsoc_gpio_set_direction (gpio * current_gpio, gpio_direction direction)
 }
 
 gpio_direction
-libsoc_gpio_get_direction (gpio * current_gpio)
+libsoc_gpio_get_direction (gpio * opaque)
 {
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+
   int fd;
   char tmp_str[STR_BUF];
 
-  if (current_gpio == NULL)
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return DIRECTION_ERROR;
@@ -271,9 +320,11 @@ libsoc_gpio_get_direction (gpio * current_gpio)
 }
 
 int
-libsoc_gpio_set_level (gpio * current_gpio, gpio_level level)
+libsoc_gpio_set_level (gpio * opaque, gpio_level level)
 {
-  if (current_gpio == NULL)
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+  
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return EXIT_FAILURE;
@@ -289,11 +340,13 @@ libsoc_gpio_set_level (gpio * current_gpio, gpio_level level)
 }
 
 gpio_level
-libsoc_gpio_get_level (gpio * current_gpio)
+libsoc_gpio_get_level (gpio * opaque)
 {
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+
   char level[2];
 
-  if (current_gpio == NULL)
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return LEVEL_ERROR;
@@ -321,12 +374,14 @@ libsoc_gpio_get_level (gpio * current_gpio)
 }
 
 int
-libsoc_gpio_set_edge (gpio * current_gpio, gpio_edge edge)
+libsoc_gpio_set_edge (gpio * opaque, gpio_edge edge)
 {
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+
   int fd;
   char path[STR_BUF];
 
-  if (current_gpio == NULL)
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return EXIT_FAILURE;
@@ -352,12 +407,14 @@ libsoc_gpio_set_edge (gpio * current_gpio, gpio_edge edge)
 }
 
 gpio_edge
-libsoc_gpio_get_edge (gpio * current_gpio)
+libsoc_gpio_get_edge (gpio * opaque)
 {
+  gpio_imp *current_gpio = (gpio_imp*) opaque;
+
   int fd;
   char tmp_str[STR_BUF];
 
-  if (current_gpio == NULL)
+  if (current_gpio == NULL || current_gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return EDGE_ERROR;
@@ -402,8 +459,8 @@ libsoc_gpio_get_edge (gpio * current_gpio)
     }
 }
 
-int
-libsoc_gpio_poll (gpio * gpio, int timeout)
+static int
+libsoc_gpio_poll (gpio_imp * gpio, int timeout)
 {
   int rc;
   char c;
@@ -429,9 +486,11 @@ libsoc_gpio_poll (gpio * gpio, int timeout)
 }
 
 int
-libsoc_gpio_wait_interrupt (gpio * gpio, int timeout)
+libsoc_gpio_wait_interrupt (gpio * opaque, int timeout)
 {
-  if (gpio == NULL)
+  gpio_imp *gpio = (gpio_imp*) opaque;
+
+  if (gpio == NULL || gpio->magic != MAGIC)
     {
       libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
       return LS_INT_ERROR;
@@ -456,9 +515,9 @@ libsoc_gpio_wait_interrupt (gpio * gpio, int timeout)
 }
 
 void *
-__libsoc_new_interrupt_callback_thread (void *void_gpio)
+__libsoc_new_interrupt_callback_thread (void *args)
 {
-  gpio *gpio = void_gpio;
+  gpio_imp *gpio = (gpio_imp*) args;
 
   gpio->callback->ready = 1;
 
@@ -477,9 +536,17 @@ __libsoc_new_interrupt_callback_thread (void *void_gpio)
 }
 
 int
-libsoc_gpio_callback_interrupt (gpio * gpio, int (*callback_fn) (void *),
+libsoc_gpio_callback_interrupt (gpio * opaque, int (*callback_fn) (void *),
 				void *arg)
 {
+  gpio_imp *gpio = (gpio_imp*) opaque;
+
+  if (gpio == NULL || gpio->magic != MAGIC)
+    {
+      libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
+      return LS_INT_ERROR;
+    }
+
   pthread_t *poll_thread = malloc (sizeof (pthread_t));
   pthread_attr_t pthread_attr;
 
@@ -523,8 +590,16 @@ libsoc_gpio_callback_interrupt (gpio * gpio, int (*callback_fn) (void *),
 }
 
 int
-libsoc_gpio_callback_interrupt_cancel (gpio * gpio)
+libsoc_gpio_callback_interrupt_cancel (gpio * opaque)
 {
+  gpio_imp *gpio = (gpio_imp*) opaque;
+
+  if (gpio == NULL || gpio->magic != MAGIC)
+    {
+      libsoc_gpio_debug (__func__, -1, "invalid gpio pointer");
+      return LS_INT_ERROR;
+    }
+
   if (gpio->callback->thread == NULL)
   {
     libsoc_gpio_debug (__func__, gpio->gpio, "callback thread was NULL");

--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -27,7 +27,7 @@ struct gpio_callback {
   int (*callback_fn) (void *);
   void *callback_arg;
   pthread_t *thread;
-  int ready;
+  pthread_mutex_t ready;
 };
 
 /**
@@ -519,11 +519,7 @@ __libsoc_new_interrupt_callback_thread (void *args)
 {
   gpio_imp *gpio = (gpio_imp*) args;
 
-  gpio->callback->ready = 1;
-
-  // There is an issue here when I believe a couple of interrupts are 
-  // missed in the test case, and they occur between ready = 1 and the 
-  // start of the poll. Any suggestions would be welcomed...
+  pthread_mutex_unlock(&gpio->callback->ready);
 
   while (1)
     {
@@ -565,7 +561,8 @@ libsoc_gpio_callback_interrupt (gpio * opaque, int (*callback_fn) (void *),
 
   gpio->callback = new_gpio_callback;
 
-  new_gpio_callback->ready = 0;
+  pthread_mutex_init(&new_gpio_callback->ready, NULL);
+  pthread_mutex_lock(&new_gpio_callback->ready);
 
   int ret = pthread_create (poll_thread, NULL,
 			    __libsoc_new_interrupt_callback_thread, gpio);
@@ -573,10 +570,7 @@ libsoc_gpio_callback_interrupt (gpio * opaque, int (*callback_fn) (void *),
   if (ret == 0)
     {
       // Wait for thread to be initialised and ready
-      while (new_gpio_callback->ready != 1)
-	{
-	  usleep (50);
-	}
+      pthread_mutex_lock(&new_gpio_callback->ready);
     }
   else
     {

--- a/lib/include/libsoc_board.h
+++ b/lib/include/libsoc_board.h
@@ -5,17 +5,10 @@
 extern "C" {
 #endif
 
-#include "libsoc_conffile.h"
-
 /**
- * \struct board_config
- * \brief a struct to hold board specific information
- * \param conf* - the board config file
+ * Opaque board data type
  */
-
-typedef struct {
-  conffile *conf;
-} board_config;
+typedef void board_config;
 
 /**
  * \fn board_config* libsoc_board_init()
@@ -35,14 +28,14 @@ board_config *libsoc_board_init();
 void libsoc_board_free(board_config *config);
 
 /**
- * \fn unsigned int libsoc_gpio_id(board_config* config, const char* pin)
+ * \fn int libsoc_gpio_id(board_config* config, const char* pin)
  * \brief find the gpio id of a given pin name
  * \param board_config* config - valid pointer to board_config
  * \param char* pin - a pin name for the board like "P49"
  * \return >=0 for gpio id or -1 on failure
  */
 
-unsigned int libsoc_board_gpio_id(board_config *config, const char* pin);
+int libsoc_board_gpio_id(board_config *config, const char* pin);
 
 #ifdef __cplusplus
 }

--- a/lib/include/libsoc_debug.h
+++ b/lib/include/libsoc_debug.h
@@ -7,6 +7,7 @@ extern "C" {
 
 void libsoc_debug(const char *func, char *format, ...) __attribute__((format(printf, 2, 3)));
 void libsoc_warn(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void libsoc_error(const char *func, const char *format, ...) __attribute__((format(printf, 2, 3)));
 int libsoc_get_debug();
 void libsoc_set_debug(int level);
 

--- a/lib/include/libsoc_gpio.h
+++ b/lib/include/libsoc_gpio.h
@@ -1,50 +1,15 @@
 #ifndef _LIBSOC_GPIO_H_
 #define _LIBSOC_GPIO_H_
 
-#include <poll.h>
-#include <pthread.h>
-#include <stdlib.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * \struct gpio_callback
- * \brief representation of an interrupt callback
- * \param int (*callback_fn)(void*) - the function to callback on interrupt
- * \param void *callback_arg - the argument to pass to the callback function
- * \param pthread_t *thread - the pthread struct on which the poll and
- *  callback function runs
- * \param int ready - signal when the pthread is ready to accept interrupts
+ * Opaque GPIO descriptor
  */
-
-struct gpio_callback {
-	int (*callback_fn) (void *);
-	void *callback_arg;
-	pthread_t *thread;
-	int ready;
-};
-
-/**
- * \struct gpio
- * \brief representation of a single requested gpio
- * \param unsigned int gpio gpio id
- * \param int value_fd file descriptor to gpio value file
- * \param struct gpio_callback *callback - struct used to store interrupt
- *  callback data
- * \param int shared - set if the request flag was shared and the GPIO was
- *  exported on request
- */
-
-typedef struct {
-	unsigned int gpio;
-	int value_fd;
-	struct gpio_callback *callback;
-	struct pollfd pfd;
-	int shared;
-} gpio;
-
+typedef void gpio;
+  
 /**
  * \enum gpio_int_ret
  * \brief defined values for return type of blocked gpio interrupts

--- a/test/board_test.c
+++ b/test/board_test.c
@@ -3,11 +3,14 @@
 #include <unistd.h>
 
 #include "libsoc_board.h"
+#include "libsoc_debug.h"
 
 #define _write(fd, buf) write(fd, buf, sizeof(buf)-1)
 
 int main(void)
 {
+  libsoc_set_debug(1);
+  
   int fails = 0;
   char template[] = "/tmp/fileXXXXXX";
   int fd = mkstemp(template);
@@ -22,7 +25,7 @@ int main(void)
   _write(fd, "GPIO_C =21 \n");
   close(fd);
 
-  setenv("LIBSOC_GPIO_CONF", template, 1);
+  setenv("LIBSOC_CONF", template, 1);
   config = libsoc_board_init();
 
 


### PR DESCRIPTION
I moved some declarations out of the board and GPIO header files and made their respective types opaque pointers.

Made the 'ready' flag in the GPIO interrupt callback structure thread-safe. That should solve the issue you are seeing with a few interrupts missed in your testcase.

Fixed the return type for board_get_pin() to allow the error value (-1) to be returned and compared without warnings.