### PR TITLE
python binding: fix 'libsoc.so: cannot open shared object file' error…

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,7 +1,7 @@
 libsocdir = $(pyexecdir)/libsoc
 libsoc_PYTHON = __init__.py gpio.py i2c.py spi.py
 
-AM_CPPFLAGS = $(PYTHON_CFLAGS) -I${top_srcdir}/lib/include -DLIBSOC_SO=\"@prefix@/lib/libsoc.so\"
+AM_CPPFLAGS = $(PYTHON_CFLAGS) -I${top_srcdir}/lib/include -DLIBSOC_SO=\"libsoc.so\"
 
 libsoc_LTLIBRARIES = _libsoc.la
 _libsoc_la_LDFLAGS = -module -avoid-version -export-dynamic $(PYTHON_LIBS)


### PR DESCRIPTION
…s on arm64

dlopen() will fail if LIBSOC_SO is hardcoded as /usr/lib/libsoc.so
on Debian-based arm64 system because shared libraries are installed
to /usr/lib/aarch64-linux-gnu/ instead of /usr/lib to support multiarch.
dlopen() will find libsoc.so from appropriate location if LIBSOC_SO
is defined as relative path.