### PR TITLE
Make set_debug a staticmethod

### DIFF
--- a/bindings/python/spi.py
+++ b/bindings/python/spi.py
@@ -56,6 +56,7 @@ class SPI(object):
             api.libsoc_spi_free(self._spi)
             self._spi = None
 
+    @staticmethod
     def set_debug(enabled):
         v = 0
         if enabled:


### PR DESCRIPTION
I think set_debug should be a staticmethod