### PR TITLE
libsoc: Fix multiple definitions of enum *mode*

### DIFF
--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -54,12 +54,12 @@ libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
   char tmp_str[STR_BUF];
   int shared = 0;
 
-  if (mode != LS_SHARED && mode != LS_GREEDY && mode != LS_WEAK)
+  if (mode != LS_GPIO_SHARED && mode != LS_GPIO_GREEDY && mode != LS_GPIO_WEAK)
     {
       libsoc_gpio_debug (__func__, gpio_id,
 			 "mode was not set, or invalid,"
-			 " setting mode to LS_SHARED");
-      mode = LS_SHARED;
+			 " setting mode to LS_GPIO_SHARED");
+      mode = LS_GPIO_SHARED;
     }
 
   libsoc_gpio_debug (__func__, gpio_id, "requested gpio");
@@ -72,12 +72,12 @@ libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
 
       switch (mode)
 	{
-	case LS_WEAK:
+	case LS_GPIO_WEAK:
 	  {
 	    return NULL;
 	  }
 
-	case LS_SHARED:
+	case LS_GPIO_SHARED:
 	  {
 	    shared = 1;
 	    break;

--- a/lib/include/libsoc_gpio.h
+++ b/lib/include/libsoc_gpio.h
@@ -94,21 +94,21 @@ typedef enum {
 /**
  * \enum gpio_mode  
  * 
- * LS_SHARED - if the gpio is already exported then it will not unexport
+ * LS_GPIO_SHARED - if the gpio is already exported then it will not unexport
  *             the GPIO on free. If it is not exported, then it will
  *             unexport on free.
  * 
- * LS_GREEDY - will succeed if the GPIO is already exported, but will 
+ * LS_GPIO_GREEDY - will succeed if the GPIO is already exported, but will 
  *             always unexport the GPIO on free.
  * 
- * LS_WEAK   - will fail if GPIO is already exported, will always unexport
+ * LS_GPIO_WEAK   - will fail if GPIO is already exported, will always unexport
  *             on free.
  */
 
 typedef enum gpio_mode {
-	LS_SHARED,
-	LS_GREEDY,
-	LS_WEAK,
+	LS_GPIO_SHARED,
+	LS_GPIO_GREEDY,
+	LS_GPIO_WEAK,
 } gpio_mode;
 
 /**

--- a/lib/include/libsoc_pwm.h
+++ b/lib/include/libsoc_pwm.h
@@ -51,21 +51,21 @@ typedef enum {
 /**
  * \enum shared_mode
  *
- * LS_SHARED - if the pwm is already exported then it will not unexport
+ * LS_PWM_SHARED - if the pwm is already exported then it will not unexport
  *             the PWM on free. If it is not exported, then it will
  *             unexport on free.
  *
- * LS_GREEDY - will succeed if the PWM is already exported, but will
+ * LS_PWM_GREEDY - will succeed if the PWM is already exported, but will
  *             always unexport the PWM on free.
  *
- * LS_WEAK   - will fail if PWM is already exported, will always unexport
+ * LS_PWM_WEAK   - will fail if PWM is already exported, will always unexport
  *             on free.
  */
 
 typedef enum {
-	LS_SHARED,
-	LS_GREEDY,
-	LS_WEAK,
+	LS_PWM_SHARED,
+	LS_PWM_GREEDY,
+	LS_PWM_WEAK,
 } shared_mode;
 
 /**

--- a/lib/pwm.c
+++ b/lib/pwm.c
@@ -43,12 +43,12 @@ pwm* libsoc_pwm_request (unsigned int chip, unsigned int pwm_num,
   char tmp_str[STR_BUF];
   int shared = 0;
 
-  if (mode != LS_SHARED && mode != LS_GREEDY && mode != LS_WEAK)
+  if (mode != LS_PWM_SHARED && mode != LS_PWM_GREEDY && mode != LS_PWM_WEAK)
   {
     libsoc_pwm_debug (__func__, chip, pwm_num,
-	    "mode was not set, or invalid, setting mode to LS_SHARED");
+	    "mode was not set, or invalid, setting mode to LS_PWM_SHARED");
 
-    mode = LS_SHARED;
+    mode = LS_PWM_SHARED;
   }
 
   libsoc_pwm_debug (__func__, chip, pwm_num, "requested PWM");
@@ -61,12 +61,12 @@ pwm* libsoc_pwm_request (unsigned int chip, unsigned int pwm_num,
 
     switch(mode)
 	  {
-	    case LS_WEAK:
+	    case LS_PWM_WEAK:
 	    {
 	      return NULL;
 	    }
 
-    	case LS_SHARED:
+	case LS_PWM_SHARED:
 	    {
 	      shared = 1;
   	    break;

--- a/static-docs/docs/c/gpio.md
+++ b/static-docs/docs/c/gpio.md
@@ -9,18 +9,18 @@
 Determines the way in which libsoc handles exporting and unexporting
 GPIOs in the Linux subsystem.
 
-* **LS_SHARED**
+* **LS_GPIO_SHARED**
 
 	if the gpio is already exported then it will not unexport
 	the GPIO on free. If it is not exported, then it will
 	unexport on free.
 
-* **LS_GREEDY**
+* **LS_GPIO_GREEDY**
 
 	will succeed if the GPIO is already exported, but will 
 	always unexport the GPIO on free.
 
-* **LS_WEAK**
+* **LS_GPIO_WEAK**
 
 	will fail if GPIO is already exported, will always unexport
 	on free.

--- a/static-docs/docs/c/pwm.md
+++ b/static-docs/docs/c/pwm.md
@@ -7,18 +7,18 @@
 Determines the way in which libsoc handles exporting and unexporting
 PWMs in the Linux subsystem.
 
-* **LS_SHARED**
+* **LS_PWM_SHARED**
 
 	if the pwm is already exported then it will not unexport
 	the pwm on free. If it is not exported, then it will
 	unexport on free.
 
-* **LS_GREEDY**
+* **LS_PWM_GREEDY**
 
 	will succeed if the pwm is already exported, but will
 	always unexport the pwm on free.
 
-* **LS_WEAK**
+* **LS_PWM_WEAK**
 
 	will fail if pwm is already exported, will always unexport
 	on free.


### PR DESCRIPTION
When using GPIO and PWM libs together compiling
fails with multiple definitions as same variables
are defined in both libsoc_gpio.h and libsoc_pwm.h

Rename the variables to avoid redefinition.