### PR TITLE
Fix issue with definition of LS_INT_TIMEOUT

### DIFF
--- a/lib/include/libsoc_gpio.h
+++ b/lib/include/libsoc_gpio.h
@@ -49,10 +49,15 @@ typedef struct {
  * \enum gpio_int_ret
  * \brief defined values for return type of blocked gpio interrupts
  */
-
+#define FAIL_LT_SUCCESS     (EXIT_FAILURE < EXIT_SUCCESS)
 typedef enum {
+    #if FAIL_LT_SUCCESS
 	LS_INT_ERROR = EXIT_FAILURE,
 	LS_INT_TRIGGERED = EXIT_SUCCESS,
+    #else
+	LS_INT_TRIGGERED = EXIT_SUCCESS,
+	LS_INT_ERROR = EXIT_FAILURE,
+    #endif
 	LS_INT_TIMEOUT,
 } gpio_int_ret;
 

--- a/static-docs/docs/index.md
+++ b/static-docs/docs/index.md
@@ -70,7 +70,7 @@ documentation for more info.
 ### Manually Building
 
 First, make sure you have the prerequisites installed. Under Debian Jessie this
-means `build-essential`, `autoconf`, `libtool-bin` and `pkg-config`. You'll also
+means `build-essential`, `autoconf`, `automake`, `libtool-bin` and `pkg-config`. You'll also
 need `python-dev` or `python3-dev`, if you wish to install the python-bindings.
 
 Then, clone libsoc from its git repository.


### PR DESCRIPTION
As per the C99 standard, an unnumbered enum gets the value of the
previous enum incremented by 1. On most Linux platforms, EXIT_FAILURE is
1, and EXIT_SUCCESS is 0 and therefore the definition of LS_INT_TIMEOUT
was getting set to 1 meaning that you can't differentiate between an
LS_INT_ERROR.

This fix will will check which order is applicable for the platform