### PR TITLE
board support: add Toradex Colibri VFxx board config files

### DIFF
--- a/contrib/board_files/colibri-vf50.conf
+++ b/contrib/board_files/colibri-vf50.conf
@@ -1,0 +1,355 @@
+# Toradex Colibri VF50 Computer On Module.
+# http://developer.toradex.com/products/colibri-vf50
+
+[board]
+dtfile = /proc/device-tree/model
+model = Toradex Colibri VF50 on Colibri Evaluation Board
+
+[GPIO]
+### Colibri VF50 SODIMM number to GPIO number mapping
+
+SODIMM_19 = 27
+SODIMM_21 = 26
+SODIMM_22 = 104
+SODIMM_23 = 10
+SODIMM_24 = 25
+SODIMM_25 = 35
+SODIMM_27 = 34
+SODIMM_28 = 30
+SODIMM_29 = 21
+SODIMM_30 = 23
+SODIMM_31 = 11
+SODIMM_32 = 82
+SODIMM_33 = 33
+SODIMM_34 = 81
+SODIMM_35 = 32
+SODIMM_36 = 80
+SODIMM_37 = 20
+SODIMM_38 = 79
+SODIMM_43 = 42
+SODIMM_44 = 109
+SODIMM_45 = 41
+SODIMM_46 = 121
+SODIMM_47 = 14
+SODIMM_48 = 123
+SODIMM_49 = 17
+SODIMM_50 = 125
+SODIMM_51 = 18
+SODIMM_52 = 112
+SODIMM_53 = 19
+SODIMM_54 = 113
+SODIMM_55 = 39
+SODIMM_56 = 107
+SODIMM_57 = 116
+SODIMM_58 = 131
+SODIMM_59 = 22
+SODIMM_59# = 52
+SODIMM_60 = 130
+SODIMM_61 = 117
+SODIMM_62 = 122
+SODIMM_63 = 38
+SODIMM_64 = 115
+SODIMM_65 = 40
+SODIMM_66 = 114
+SODIMM_67 = 31
+SODIMM_67# = 51
+SODIMM_68 = 105
+SODIMM_69 = 64
+SODIMM_70 = 129
+SODIMM_71 = 45
+SODIMM_72 = 133
+SODIMM_73 = 43
+SODIMM_74 = 124
+SODIMM_75 = 91
+SODIMM_76 = 128
+SODIMM_77 = 44
+SODIMM_78 = 132
+SODIMM_79 = 49
+SODIMM_80 = 120
+SODIMM_81 = 29
+SODIMM_82 = 106
+SODIMM_85 = 53
+SODIMM_86 = 84
+SODIMM_88 = 87
+SODIMM_89 = 2
+SODIMM_90 = 85
+SODIMM_92 = 86
+SODIMM_93 = 98
+SODIMM_94 = 28
+SODIMM_95 = 103
+SODIMM_96 = 134
+SODIMM_97 = 50
+SODIMM_98 = 46
+SODIMM_99 = 65
+SODIMM_100 = 92
+SODIMM_101 = 47
+SODIMM_102 = 93
+SODIMM_103 = 48
+SODIMM_104 = 66
+SODIMM_105 = 96
+SODIMM_106 = 63
+SODIMM_107 = 67
+SODIMM_127 = 68
+SODIMM_129 = 83
+SODIMM_131 = 108
+SODIMM_133 = 88
+SODIMM_134 = 7
+SODIMM_135 = 89
+SODIMM_136 = 126
+SODIMM_137 = 102
+SODIMM_138 = 127
+SODIMM_140 = 118
+SODIMM_142 = 119
+SODIMM_144 = 110
+SODIMM_146 = 111
+SODIMM_184 = 69
+SODIMM_186 = 70
+SODIMM_188 = 90
+SODIMM_190 = 15
+SODIMM_192 = 16
+SODIMM_194 = 37
+SODIMM_196 = 36
+
+### Colibri Evaluation Board location to GPIO mapping
+
+# (X9)
+X9_12 = 25
+X9_11 = 104
+X9_13 = 109
+X9_4 = 41
+X9_28 = 112
+X9_27 = 125
+X9_25 = 123
+X9_23 = 121
+X9_30 = 113
+X9_5 = 39
+X9_42 = 107
+X9_33 = 116
+X9_18 = 131
+X9_17 = 130
+X9_34 = 117
+X9_24 = 122
+X9_6 = 38
+X9_32 = 115
+X9_31 = 114
+X9_44 = 105
+X9_16 = 129
+X9_46 = 45
+X9_20 = 133
+X9_26 = 124
+X9_14 = 128
+X9_19 = 132
+X9_21 = 120
+X9_45 = 106
+X9_7 = 92
+X9_9 = 93
+X9_35 = 126
+X9_37 = 127
+X9_38 = 118
+X9_39 = 119
+X9_47 = 37
+X9_48 = 36
+X9_41 = 111
+X9_10 = 66
+X9_40 = 110
+
+# (X10)
+X10_2 = 27
+X10_3 = 26
+X10_4 = 10
+X10_5 = 35
+X10_6 = 34
+X10_27 = 30
+X10_7 = 21
+X10_28 = 23
+X10_9 = 11
+X10_30 = 82
+X10_19 = 33
+X10_14 = 81
+X10_11 = 32
+X10_16 = 80
+X10_12 = 20
+X10_17 = 79
+X10_18 = 42
+X10_19 = 14
+X10_23 = 17
+X10_24 = 18
+X10_25 = 19
+X10_26 = 22
+X10_26# = 52
+X10_30 = 31
+X10_30# = 51
+X10_31 = 43
+X10_32 = 84
+x10_33 = 87
+X10_34 = 85
+X10_35 = 86
+X10_37 = 96
+X10_42 = 68
+X10_38 = 67
+X10_47 = 83
+X10_48 = 108
+X10_41 = 88
+X10_39 = 63
+X10_40 = 89
+X10_49 = 102
+X10_20 = 15
+X10_21 = 16
+
+# (X22)
+X22_14 = 40
+X22_21 = 64
+X22_3 = 91
+X22_22 = 44
+X22_9 = 49
+X22_6 = 29
+X22_13 = 53
+X22_5 = 28
+X22_4 = 134
+X22_10 = 50
+X22_18 = 46
+X22_7 = 47
+X22_8 = 48
+
+# EX A
+EX_A_26 = 2
+EX_A_28 = 98
+EX_A_31 = 65
+EX_A_27 = 96
+EX_A_32 = 88
+EX_A_23 = 126
+EX_A_22 = 127
+EX_A_22 = 118
+EX_A_21 = 111
+EX_A_20 = 90
+
+# EX B
+EX_B_28 = 103
+EX_B_26 = 67
+EX_B_23 = 7
+EX_B_21 = 110
+EX_B_20 = 70
+
+# EX C
+EX_C_27 = 63
+EX_C_32 = 68
+EX_C_31 = 89
+EX_C_21 = 119
+EX_C_20 = 69
+
+### Colibri Aster Carrier Board location to GPIO mapping
+
+# Extension Connector (X20)
+# This extension connector pinout is compatible with header pins available on
+# the Raspberry Pi, Type B+ board.
+# NOTE: Some of these functions might change depending on the Colibri module that is used.
+X20_32 = 30
+# Via R127
+x20_27 = 21
+X20_33 = 23
+X20_36 = 82
+X20_11 = 81
+X20_10 = 80
+# Via R128
+X20_28 = 20
+X20_8 = 79
+# Via R120
+X20_12 = 22
+X20_24 = 40
+# Via R122
+X20_35 = 31
+# Via R124
+X20_40 = 64
+X20_15 = 45
+X20_38 = 91
+X20_37 = 49
+X20_31 = 29
+x20_26 = 84
+X20_23 = 87
+X20_21 = 85
+X20_19 = 86
+X20_29 = 28
+X20_7 = 134
+X20_13 = 50
+X20_16 = 46
+# Via R125
+X20_40 = 92
+X20_22 = 47
+X20_18 = 48
+# Via R121
+X20_12 = 89
+# Via R123
+X20_35 = 90
+X20_3 = 37
+# Via R126
+#X20_12 = 37
+X20_5 = 36
+# Via R129
+#X20_28 = 36
+
+# Arduino Shield header: Digital I/OPins (X17)
+UNO_GPIO1 = 41
+UNO_GPIO2 = 31
+UNO_GPIO2# = 51
+UNO_GPIO3 = 88
+UNO_GPIO4 = 30
+UNO_GPIO5 = 23
+UNO_GPIO6 = 39
+UNO_GPIO7 = 38
+UNO_GPIO8 = 22
+UNO_GPIO8# = 52
+UNO_SPI_MOSI = 86
+UNO_SPI_MISO = 85
+UNO_SPI_SCK = 87
+UNO_I2C_SDA = 37
+UNO_I2C_SCL = 36
+
+### Colibri Iris Carrier Board location to GPIO mapping
+
+# Extension Connctor (X16)
+X16_5 = 37
+X16_6 = 36
+X16_8 = 87
+X16_9 = 84
+X16_10 = 85
+X16_11 = 86
+X16_13 = 46
+X16_14 = 88
+X16_15 = 48
+X16_16 = 47
+X16_17 = 50
+X16_18 = 53
+X16_19 = 49
+X16_20 = 41
+X16_37 = 22
+X16_37# = 52
+X16_38 = 30
+X16_39 = 23
+X16_40 = 31
+X16_40# = 51
+
+### Colibri Viola Carrier Board location to GPIO mapping
+
+# Extension Connector (X9)
+X9_42 = 30
+X9_16 = 41
+X9_17 = 39
+X9_41 = 22
+X9_18 = 38
+X9_44 = 31
+X9_44# = 51
+X9_15 = 49
+X9_14 = 53
+X9_13 = 50
+X9_9 = 46
+X9_12 = 47
+X9_11 = 48
+X9_10 = 88
+X9_8 = 89
+
+# (X10)
+X10_8 = 29
+X10_9 = 28
+X10_10 = 134
+X10_11 = 40
+X10_12 = 91

--- a/contrib/board_files/colibri-vf61.conf
+++ b/contrib/board_files/colibri-vf61.conf
@@ -1,0 +1,355 @@
+# Toradex Colibri VF61 Computer On Module.
+# http://developer.toradex.com/products/colibri-vf61
+
+[board]
+dtfile = /proc/device-tree/model
+model = Toradex Colibri VF61 on Colibri Evaluation Board
+
+[GPIO]
+### Colibri VF61 SODIMM number to GPIO number mapping
+
+SODIMM_19 = 27
+SODIMM_21 = 26
+SODIMM_22 = 104
+SODIMM_23 = 10
+SODIMM_24 = 25
+SODIMM_25 = 35
+SODIMM_27 = 34
+SODIMM_28 = 30
+SODIMM_29 = 21
+SODIMM_30 = 23
+SODIMM_31 = 11
+SODIMM_32 = 82
+SODIMM_33 = 33
+SODIMM_34 = 81
+SODIMM_35 = 32
+SODIMM_36 = 80
+SODIMM_37 = 20
+SODIMM_38 = 79
+SODIMM_43 = 42
+SODIMM_44 = 109
+SODIMM_45 = 41
+SODIMM_46 = 121
+SODIMM_47 = 14
+SODIMM_48 = 123
+SODIMM_49 = 17
+SODIMM_50 = 125
+SODIMM_51 = 18
+SODIMM_52 = 112
+SODIMM_53 = 19
+SODIMM_54 = 113
+SODIMM_55 = 39
+SODIMM_56 = 107
+SODIMM_57 = 116
+SODIMM_58 = 131
+SODIMM_59 = 22
+SODIMM_59# = 52
+SODIMM_60 = 130
+SODIMM_61 = 117
+SODIMM_62 = 122
+SODIMM_63 = 38
+SODIMM_64 = 115
+SODIMM_65 = 40
+SODIMM_66 = 114
+SODIMM_67 = 31
+SODIMM_67# = 51
+SODIMM_68 = 105
+SODIMM_69 = 64
+SODIMM_70 = 129
+SODIMM_71 = 45
+SODIMM_72 = 133
+SODIMM_73 = 43
+SODIMM_74 = 124
+SODIMM_75 = 91
+SODIMM_76 = 128
+SODIMM_77 = 44
+SODIMM_78 = 132
+SODIMM_79 = 49
+SODIMM_80 = 120
+SODIMM_81 = 29
+SODIMM_82 = 106
+SODIMM_85 = 53
+SODIMM_86 = 84
+SODIMM_88 = 87
+SODIMM_89 = 2
+SODIMM_90 = 85
+SODIMM_92 = 86
+SODIMM_93 = 98
+SODIMM_94 = 28
+SODIMM_95 = 103
+SODIMM_96 = 134
+SODIMM_97 = 50
+SODIMM_98 = 46
+SODIMM_99 = 65
+SODIMM_100 = 92
+SODIMM_101 = 47
+SODIMM_102 = 93
+SODIMM_103 = 48
+SODIMM_104 = 66
+SODIMM_105 = 96
+SODIMM_106 = 63
+SODIMM_107 = 67
+SODIMM_127 = 68
+SODIMM_129 = 83
+SODIMM_131 = 108
+SODIMM_133 = 88
+SODIMM_134 = 7
+SODIMM_135 = 89
+SODIMM_136 = 126
+SODIMM_137 = 102
+SODIMM_138 = 127
+SODIMM_140 = 118
+SODIMM_142 = 119
+SODIMM_144 = 110
+SODIMM_146 = 111
+SODIMM_184 = 69
+SODIMM_186 = 70
+SODIMM_188 = 90
+SODIMM_190 = 15
+SODIMM_192 = 16
+SODIMM_194 = 37
+SODIMM_196 = 36
+
+### Colibri Evaluation Board location to GPIO mapping
+
+# (X9)
+X9_12 = 25
+X9_11 = 104
+X9_13 = 109
+X9_4 = 41
+X9_28 = 112
+X9_27 = 125
+X9_25 = 123
+X9_23 = 121
+X9_30 = 113
+X9_5 = 39
+X9_42 = 107
+X9_33 = 116
+X9_18 = 131
+X9_17 = 130
+X9_34 = 117
+X9_24 = 122
+X9_6 = 38
+X9_32 = 115
+X9_31 = 114
+X9_44 = 105
+X9_16 = 129
+X9_46 = 45
+X9_20 = 133
+X9_26 = 124
+X9_14 = 128
+X9_19 = 132
+X9_21 = 120
+X9_45 = 106
+X9_7 = 92
+X9_9 = 93
+X9_35 = 126
+X9_37 = 127
+X9_38 = 118
+X9_39 = 119
+X9_47 = 37
+X9_48 = 36
+X9_41 = 111
+X9_10 = 66
+X9_40 = 110
+
+# (X10)
+X10_2 = 27
+X10_3 = 26
+X10_4 = 10
+X10_5 = 35
+X10_6 = 34
+X10_27 = 30
+X10_7 = 21
+X10_28 = 23
+X10_9 = 11
+X10_30 = 82
+X10_19 = 33
+X10_14 = 81
+X10_11 = 32
+X10_16 = 80
+X10_12 = 20
+X10_17 = 79
+X10_18 = 42
+X10_19 = 14
+X10_23 = 17
+X10_24 = 18
+X10_25 = 19
+X10_26 = 22
+X10_26# = 52
+X10_30 = 31
+X10_30# = 51
+X10_31 = 43
+X10_32 = 84
+x10_33 = 87
+X10_34 = 85
+X10_35 = 86
+X10_37 = 96
+X10_42 = 68
+X10_38 = 67
+X10_47 = 83
+X10_48 = 108
+X10_41 = 88
+X10_39 = 63
+X10_40 = 89
+X10_49 = 102
+X10_20 = 15
+X10_21 = 16
+
+# (X22)
+X22_14 = 40
+X22_21 = 64
+X22_3 = 91
+X22_22 = 44
+X22_9 = 49
+X22_6 = 29
+X22_13 = 53
+X22_5 = 28
+X22_4 = 134
+X22_10 = 50
+X22_18 = 46
+X22_7 = 47
+X22_8 = 48
+
+# EX A
+EX_A_26 = 2
+EX_A_28 = 98
+EX_A_31 = 65
+EX_A_27 = 96
+EX_A_32 = 88
+EX_A_23 = 126
+EX_A_22 = 127
+EX_A_22 = 118
+EX_A_21 = 111
+EX_A_20 = 90
+
+# EX B
+EX_B_28 = 103
+EX_B_26 = 67
+EX_B_23 = 7
+EX_B_21 = 110
+EX_B_20 = 70
+
+# EX C
+EX_C_27 = 63
+EX_C_32 = 68
+EX_C_31 = 89
+EX_C_21 = 119
+EX_C_20 = 69
+
+### Colibri Aster Carrier Board location to GPIO mapping
+
+# Extension Connector (X20)
+# This extension connector pinout is compatible with header pins available on
+# the Raspberry Pi, Type B+ board.
+# NOTE: Some of these functions might change depending on the Colibri module that is used.
+X20_32 = 30
+# Via R127
+x20_27 = 21
+X20_33 = 23
+X20_36 = 82
+X20_11 = 81
+X20_10 = 80
+# Via R128
+X20_28 = 20
+X20_8 = 79
+# Via R120
+X20_12 = 22
+X20_24 = 40
+# Via R122
+X20_35 = 31
+# Via R124
+X20_40 = 64
+X20_15 = 45
+X20_38 = 91
+X20_37 = 49
+X20_31 = 29
+x20_26 = 84
+X20_23 = 87
+X20_21 = 85
+X20_19 = 86
+X20_29 = 28
+X20_7 = 134
+X20_13 = 50
+X20_16 = 46
+# Via R125
+X20_40 = 92
+X20_22 = 47
+X20_18 = 48
+# Via R121
+X20_12 = 89
+# Via R123
+X20_35 = 90
+X20_3 = 37
+# Via R126
+#X20_12 = 37
+X20_5 = 36
+# Via R129
+#X20_28 = 36
+
+# Arduino Shield header: Digital I/OPins (X17)
+UNO_GPIO1 = 41
+UNO_GPIO2 = 31
+UNO_GPIO2# = 51
+UNO_GPIO3 = 88
+UNO_GPIO4 = 30
+UNO_GPIO5 = 23
+UNO_GPIO6 = 39
+UNO_GPIO7 = 38
+UNO_GPIO8 = 22
+UNO_GPIO8# = 52
+UNO_SPI_MOSI = 86
+UNO_SPI_MISO = 85
+UNO_SPI_SCK = 87
+UNO_I2C_SDA = 37
+UNO_I2C_SCL = 36
+
+### Colibri Iris Carrier Board location to GPIO mapping
+
+# Extension Connctor (X16)
+X16_5 = 37
+X16_6 = 36
+X16_8 = 87
+X16_9 = 84
+X16_10 = 85
+X16_11 = 86
+X16_13 = 46
+X16_14 = 88
+X16_15 = 48
+X16_16 = 47
+X16_17 = 50
+X16_18 = 53
+X16_19 = 49
+X16_20 = 41
+X16_37 = 22
+X16_37# = 52
+X16_38 = 30
+X16_39 = 23
+X16_40 = 31
+X16_40# = 51
+
+### Colibri Viola Carrier Board location to GPIO mapping
+
+# Extension Connector (X9)
+X9_42 = 30
+X9_16 = 41
+X9_17 = 39
+X9_41 = 22
+X9_18 = 38
+X9_44 = 31
+X9_44# = 51
+X9_15 = 49
+X9_14 = 53
+X9_13 = 50
+X9_9 = 46
+X9_12 = 47
+X9_11 = 48
+X9_10 = 88
+X9_8 = 89
+
+# (X10)
+X10_8 = 29
+X10_9 = 28
+X10_10 = 134
+X10_11 = 40
+X10_12 = 91


### PR DESCRIPTION
Add Toradex Colibri VF50/VF61 SoM Board config files.

Board config files covers all the Toradex supported
Colibri carrier Boards, viz.

- Colibri Evaluation Board[1]
- Colibri Iris Carrier Board[2]
- Colibri Viola Carrier Board[3]
- Colibri Aster Carrier Board[4]

[1] http://developer.toradex.com/products/colibri-evaluation-board
[2] http://developer.toradex.com/products/iris-carrier-board
[3] http://developer.toradex.com/products/viola-carrier-board
[4] http://developer.toradex.com/products/aster-carrier-board