### PR TITLE
gpio,pwm: add delay to allow udev rules to complete

### DIFF
--- a/lib/gpio.c
+++ b/lib/gpio.c
@@ -104,6 +104,9 @@ libsoc_gpio_request (unsigned int gpio_id, gpio_mode mode)
       if (file_close (fd))
 	return NULL;
 
+      /* Give udev some time to execute the rules of the exported GPIO */
+      usleep(200000);
+
       sprintf (tmp_str, "/sys/class/gpio/gpio%d", gpio_id);
 
       if (!file_valid (tmp_str))

--- a/lib/pwm.c
+++ b/lib/pwm.c
@@ -88,6 +88,9 @@ pwm* libsoc_pwm_request (unsigned int chip, unsigned int pwm_num,
       return NULL;
     }
 
+    /* Give udev some time to execute the rules of the exported PWM */
+    usleep(200000);
+
     sprintf(tmp_str, "/sys/class/pwm/pwmchip%d/pwm%d/enable", chip, pwm_num);
 
     if (!file_valid(tmp_str))


### PR DESCRIPTION
After exporting a GPIO or PWM, we need to give some time for udev rules
to complete, before actually trying to access the newly created entries
in the sysfs.

This solves a problem, where udev was setting the mode and group of
the newly created files, so they are accessible for users (not root)
belonging to that group.

Signed-off-by: Javier Viguera <javier.viguera@digi.com>