### PR TITLE
added GPIO number mappings for DragonBoard820c

### DIFF
--- a/contrib/board_files/dragonboard820c.conf
+++ b/contrib/board_files/dragonboard820c.conf
@@ -1,0 +1,32 @@
+[board]
+model = Qualcomm Technologies, Inc. APQ 8096SGE SBC
+
+[GPIO]
+# dragonboard 820c pin layout
+#<Pin Name> <SoC Num>
+GPIO-A = 80
+GPIO-B = 29
+GPIO-C = 124
+GPIO-D = 24
+GPIO-E = 62
+GPIO-F = 507
+GPIO-G = 10
+GPIO-H = 8
+GPIO-I = 25
+GPIO-J = 26
+GPIO-K = 23
+GPIO-L = 133
+
+# include mappings by pin number on board
+GPIO-23 = 80
+GPIO-24 = 29
+GPIO-25 = 124
+GPIO-26 = 24
+GPIO-27 = 62
+GPIO-28 = 507
+GPIO-29 = 10
+GPIO-30 = 8
+GPIO-31 = 25
+GPIO-32 = 26
+GPIO-33 = 23
+GPIO-34 = 133


### PR DESCRIPTION
Compared the low-speed connector pages of **[DB410c](https://github.com/96boards/documentation/blob/master/consumer/dragonboard410c/hardware-docs/HardwareManual_DragonBoard.pdf)** (p15) and **[DB820c ](https://github.com/96boards/documentation/blob/master/consumer/dragonboard820c/hardware-docs/files/db820c-hw-user-manual.pdf)** (p16)
I also tested on my DB820c.
