### PR TITLE
Clear errno before strtol

### DIFF
--- a/lib/conffile.c
+++ b/lib/conffile.c
@@ -164,6 +164,7 @@ conffile_get_int(conffile *conf, const char *sectname, const char *key, int defv
   if (strval)
     {
       char *endptr;
+      errno = 0;
       val = strtol(strval, &endptr, 10);
       if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN))
             || (errno != 0 && val == 0) || endptr == strval || *endptr != '\0'


### PR DESCRIPTION
Hi,
If a pin maps to 0 at board conf file and errno was previously set to anything before running strtol, then you get a wrong error, failing to get the pin number.

This fix clears the errno value so the function is not affected by external errors anymore.